### PR TITLE
fix: Cache post for a day

### DIFF
--- a/api/src/functions/graphql.ts
+++ b/api/src/functions/graphql.ts
@@ -17,8 +17,15 @@ export const handler = createGraphQLHandler({
   extraPlugins: [
     useResponseCache({
       session: () => null,
+      // by default cache all operations for 1 hour
+      ttl: 1_000 * 60 * 60,
+      ttlPerType: {
+        // only cache query operations containing Post for 1 day
+        Post: 1_000 * 60 * 60 * 24,
+      },
       ttlPerSchemaCoordinate: {
-        'Query.recentPosts': 10 * 1_000, // 10 seconds
+        // cache for 1 day
+        'Query.recentPosts': 1_000 * 60 * 60 * 24,
       },
     }),
   ],


### PR DESCRIPTION
The GraphQL response cache was setup only to cache the recentPosts query for 10 seconds - but the individual Post was set to cache forever.

This meant that when a blog post was updated in Hashnode, the GraphQL response cache kept the old cached copy and delivered that back.

This PR sets the default til to an hour for all operations and any Post or recent Posts to 1 day.

A followup PR will provide a mechanism to invalidate the cache on build -- or maybe via a webhook from Hashnode to invalidate open edit so app can present latest content.