### PR TITLE
feat: Webhook to invalidate Blog Post response cache when post on Hashnode is updated

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -17,3 +17,6 @@ PRISMA_HIDE_UPDATE_MESSAGE=true
 # Most applications want "debug" or "info" during dev, "trace" when you have issues and "warn" in production.
 # Ordered by how verbose they are: trace | debug | info | warn | error | silent
 # LOG_LEVEL=debug
+
+# Used by Hashnode to invaldate posts cache on publishing or editing blog
+INVALIDATE_POSTS_HOOK_SECRET=secret

--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@
 # TEST_DATABASE_URL=file:./.redwood/test.db
 # PRISMA_HIDE_UPDATE_MESSAGE=true
 # LOG_LEVEL=trace
+# Used by Hashnode to invaldate posts cache on publishing or editing blog
+INVALIDATE_POSTS_HOOK_SECRET=secret

--- a/README.md
+++ b/README.md
@@ -108,3 +108,34 @@ The new icon will be available within the `Icon` component, using the same name 
 ## Blog Posts
 
 Blog posts are written and managed inside [Hashnode](https://hashnode.com/).
+
+## Caching
+
+While blog posts and publications are fetched from Hashnode, Redwood's GraphQL server is also caching its responses.
+
+See the `graphql` function for the `useResponseCache` config.
+
+### Invalidating
+
+The GraphQL mutations:
+
+* invalidatePost(slug: string)
+* invalidatePosts
+
+will purge the Posts from the response cache.
+
+A webhook at /
+
+For example:
+
+```bash
+curl http://localhost:8911/invalidatePostsHook
+```
+
+Where the hostname is local or
+
+```bash
+curl https://redwoodjs.com/.netlify/functions/invalidatePostsHook
+```
+
+in production.

--- a/api/src/functions/graphql.ts
+++ b/api/src/functions/graphql.ts
@@ -1,4 +1,7 @@
-import { useResponseCache } from '@graphql-yoga/plugin-response-cache'
+import {
+  createInMemoryCache,
+  useResponseCache,
+} from '@graphql-yoga/plugin-response-cache'
 
 import { createGraphQLHandler } from '@redwoodjs/graphql-server'
 
@@ -8,6 +11,8 @@ import services from 'src/services/**/*.{js,ts}'
 
 import { db } from 'src/lib/db'
 import { logger } from 'src/lib/logger'
+
+export const cache = createInMemoryCache()
 
 export const handler = createGraphQLHandler({
   loggerConfig: { logger, options: {} },
@@ -27,6 +32,7 @@ export const handler = createGraphQLHandler({
         // cache for 1 day
         'Query.recentPosts': 1_000 * 60 * 60 * 24,
       },
+      cache,
     }),
   ],
   onException: () => {

--- a/api/src/functions/invalidatePostsHook/invalidatePostsHook.ts
+++ b/api/src/functions/invalidatePostsHook/invalidatePostsHook.ts
@@ -1,0 +1,68 @@
+import type { APIGatewayEvent, Context } from 'aws-lambda'
+
+import {
+  verifyEvent,
+  VerifyOptions,
+  WebhookVerificationError,
+} from '@redwoodjs/api/webhooks'
+
+import { logger } from 'src/lib/logger'
+import { invalidatePosts } from 'src/services/hashnode'
+/**
+ * This function is the webhook handler for the Hashnode API.
+ * It invalidates the cache for all posts.
+ */
+export const handler = async (event: APIGatewayEvent, _context: Context) => {
+  logger.info(`${event.httpMethod} ${event.path}: invalidatePostsHook function`)
+
+  try {
+    const options = {
+      signatureHeader: 'x-hashnode-signature',
+      // You may override these defaults
+      // tolerance: 60_000,
+      // timestamp: new Date().getDate() - 1,
+    } as VerifyOptions
+
+    logger.info({ webhook: 'invalidatePostsHook', options }, 'Verifying event')
+
+    verifyEvent('timestampSchemeVerifier', {
+      event,
+      secret: process.env.INVALIDATE_POSTS_HOOK_SECRET,
+      options,
+    })
+
+    logger.info({ webhook: 'invalidatePostsHook', options }, 'Verified!')
+
+    const status = await invalidatePosts()
+
+    logger.info({ webhook: 'invalidatePostsHook', status }, 'Posts invalidated')
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        data: { webhook: 'invalidatePostsHook', status },
+      }),
+    }
+  } catch (error) {
+    if (error instanceof WebhookVerificationError) {
+      logger.warn({ webhook: 'invalidatePostsHook-background' }, 'Unauthorized')
+      return {
+        statusCode: 401,
+      }
+    } else {
+      logger.error({ webhook: 'invalidatePostsHook', error }, error.message)
+      return {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        statusCode: 500,
+        body: JSON.stringify({
+          error: error.message,
+        }),
+      }
+    }
+  }
+}

--- a/api/src/graphql/hashnode.sdl.ts
+++ b/api/src/graphql/hashnode.sdl.ts
@@ -61,4 +61,12 @@ export const schema = gql`
     "Fetches a single post by its slug."
     post(slug: String!): Post! @skipAuth
   }
+
+  type Mutation {
+    "Invalidates a single cached post by its slug."
+    invalidatePost(slug: String!): Boolean @skipAuth
+
+    "Invalidates all cached posts."
+    invalidatePosts: Boolean @skipAuth
+  }
 `


### PR DESCRIPTION
This PR adds a web hook function that Hashnode will send when updating, publishing or deleting a post:

![image](https://github.com/redwoodjs/bighorn-website/assets/1051633/3fcdb1c6-f670-4338-bfb5-8cb85d4a4e1f)

It uses the invalidatePosts service to invalidate all posts -- since we don't have many, but this could be changed to invalidate just one Post in future.

The web hook is verified using Hashnode's signing signature:

![image](https://github.com/redwoodjs/bighorn-website/assets/1051633/286e4dc2-12c4-499e-bab6-188fc2f45bc0)


which RedwoodJs supports via the `timestampSchemeVerifier` verifier, so no custom code is needed so verify the signature:

```
    const options = {
      signatureHeader: 'x-hashnode-signature',
      // You may override these defaults
      // tolerance: 60_000,
      // timestamp: new Date().getDate() - 1,
    } as VerifyOptions

    logger.info({ webhook: 'invalidatePostsHook', options }, 'Verifying event')

    verifyEvent('timestampSchemeVerifier', {
      event,
      secret: process.env.INVALIDATE_POSTS_HOOK_SECRET,
      options,
    })
```

When Hashnode sends the webhook Posts will be purged from cache.

To configure:

1. envar needs to be added to Netlify from production (done)
2. Hashnode webhook point to production (done but needs to be verified)
