### PR TITLE
fix: Fetch og metadata and image from Hashnode

### DIFF
--- a/api/src/services/hashnode.ts
+++ b/api/src/services/hashnode.ts
@@ -47,6 +47,9 @@ export const recentPosts = async ({
                 html
                 text
               }
+              ogMetaData {
+                image
+              },
               coverImage {
                 url
               }
@@ -113,6 +116,9 @@ export const post = async ({ slug }: QueryPostArgs): Promise<Query['post']> => {
             html
             text
           }
+          ogMetaData {
+            image
+          },
           coverImage {
             url
           }


### PR DESCRIPTION
This PR fixes fetching the ogMetadata information for recent and individual posts.

Previously, it set just what HN calls the "coverImage".

The cell queries requested the information and set to Metadata already, but the info wasn't being fetch so then the ogMeta image was null.

Now it can get set:

![image](https://github.com/redwoodjs/bighorn-website/assets/1051633/e55998d4-5405-4c32-9549-286fb5eb6767)

Note: This will work when SSR or Netlify's prerender feature is set.