### PR TITLE
fix static assets conflicts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -52,6 +52,18 @@
   force = true
 
 [[redirects]]
+  from = "/assets/*"
+  to = "https://redwoodjs-docs.netlify.app/assets/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/img/*"
+  to = "https://redwoodjs-docs.netlify.app/img/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/newsletter"
   to = "https://mailchi.mp/redwoodjs/redwoodjs-newsletter"
   force = true

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,6 +11,15 @@ dns.setDefaultResultOrder('verbatim')
 
 const viteConfig: UserConfig = {
   plugins: [redwood()],
+  build: {
+    rollupOptions: {
+      output: {
+        assetFileNames: 'static/[name]-[hash][extname]',
+        entryFileNames: 'static/[name]-[hash].js',
+        chunkFileNames: 'static/[name]-[hash].js',
+      },
+    },
+  },
 }
 
 export default defineConfig(viteConfig)


### PR DESCRIPTION
Both the Redwood docs at https://github.com/redwoodjs/redwood/tree/main/docs/docs and this app write built files to a directory called `assets`. This results in conflicts when they're both deployed since we have two sites under one hostname (`redwoodjs.com`). For instance, right now the docusaurus site isn't getting what it needs (see https://6601ea0312b99d00082115bc--bighorn.netlify.app/docs/introduction and scroll down 😅):

<img width="1614" alt="image" src="https://github.com/redwoodjs/bighorn-website/assets/32992335/0338a6bd-6d3c-4459-9a4a-ce492cba1c07">


We can try making one of them write to another location. This is always harder than it has to be of course cause build tools and Vite is no exception (sorry). Here I'm making this app output to `/static` instead of `/assets`. That way both sites should be able to get the static assets they need.

I compared `web/dist` before and after this change and think I covered everything.