### PR TITLE
fix: Rename Invalidate Post Webhook to ensure Function Loads properly when deployed to Netlify

### DIFF
--- a/api/src/functions/whInvalidatePostsHook/whInvalidatePostsHook.ts
+++ b/api/src/functions/whInvalidatePostsHook/whInvalidatePostsHook.ts
@@ -11,6 +11,12 @@ import { invalidatePosts } from 'src/services/hashnode'
 /**
  * This function is the webhook handler for the Hashnode API.
  * It invalidates the cache for all posts.
+ *
+ * Note: This function is protected by a secret signature.
+ *
+ * Important: This function is prefixed with `wh` to indicate it is a webhook
+ * and also to ensure that the graphql function loads first on Netlify
+ * and thus merges the schema and invalidatePost can be imported properly.
  */
 export const handler = async (event: APIGatewayEvent, _context: Context) => {
   logger.info(`${event.httpMethod} ${event.path}: invalidatePostsHook function`)
@@ -23,7 +29,10 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
       // timestamp: new Date().getDate() - 1,
     } as VerifyOptions
 
-    logger.info({ webhook: 'invalidatePostsHook', options }, 'Verifying event')
+    logger.info(
+      { webhook: 'whInvalidatePostsHook', options },
+      'Verifying event'
+    )
 
     verifyEvent('timestampSchemeVerifier', {
       event,
@@ -31,11 +40,13 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
       options,
     })
 
-    logger.info({ webhook: 'invalidatePostsHook', options }, 'Verified!')
+    logger.info({ webhook: 'whInvalidatePostsHook', options }, 'Verified!')
 
     const status = await invalidatePosts()
-
-    logger.info({ webhook: 'invalidatePostsHook', status }, 'Posts invalidated')
+    logger.info(
+      { webhook: 'whInvalidatePostsHook', status },
+      'Posts invalidated'
+    )
 
     return {
       statusCode: 200,
@@ -43,7 +54,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        data: { webhook: 'invalidatePostsHook', status },
+        data: { webhook: 'whInvalidatePostsHook', status },
       }),
     }
   } catch (error) {


### PR DESCRIPTION
When found that when deploying to Netlify, the following error occurred with trying to invoke the web hook to invalidate posts:

```
Mar 27, 10:09:11 AM: {"level":60,"time":1711548551681,"pid":8,"hostname":"169.254.9.5","err":{"type":"ReferenceError","message":"Cannot access 'invalidatePost' before initialization","stack":"ReferenceError: Cannot access 'invalidatePost' before initialization\n    at Object.invalidatePost (/var/task/api/dist/services/hashnode.js:20:25)\n    at Object.get [as invalidatePost] (/var/task/api/dist/services/hashnode.js:13:45)\n    at Object.get [as invalidatePost] (/var/task/api/dist/functions/graphql.js:15:45)\n    at /var/task/node_modules/lodash/lodash.js:4967:32\n    at baseMerge (/var/task/node_modules/lodash/lodash.js:3642:7)\n    at /var/task/node_modules/lodash/lodash.js:13506:7\n    at /var/task/node_modules/lodash/lodash.js:4915:13\n    at apply (/var/task/node_modules/lodash/lodash.js:489:27)\n    at /var/task/node_modules/lodash/lodash.js:6627:16\n    at mergeResolversWithServices (/var/task/node_modules/@redwoodjs/graphql-server/dist/makeMergedSchema.js:144:50)"},"msg":"\n ⚠️ GraphQL server crashed \n"}
```

I was able to recreate not with `yarn rw dev`, but with `netlify dev` locally:

```bash
◈ Reloading function graphql...
◈ Reloading function invalidatePostsHook...
◈ Reloaded function graphql
◈ Reloaded function invalidatePostsHook
api | Starting API Server...
api | Loading server config from /redwoodjs/bighorn-website/api/server.config.js
Request from ::1: POST /.netlify/functions/graphql
api | Importing Server Functions... 
api | 10:13:26 💀 
api |  ⚠️ GraphQL server crashed 
api |  
api | 
api | 🚨 ReferenceError Info
api | 
api | {}
api |  
api | 🥞 Error Stack
api | 
api | ReferenceError: Cannot access 'invalidatePost' before initialization
api |     at Object.invalidatePost (//redwoodjs/bighorn-website/api/src/services/hashnode.ts:1:1)
api |     at Object.get [as invalidatePost] (//redwoodjs/bighorn-website/api/dist/services/hashnode.js:13:45)
api |     at Object.get [as invalidatePost] (/edwoodjs/bighorn-website/api/dist/functions/graphql.js:15:45)
api |     at //redwoodjs/bighorn-website/node_modules/lodash/lodash.js:4967:32
```

Turns out with Netlify here, the functions are being loaded in alphabetical order -- so the invalidatePostsHook loads before the graphql function and "for some reason" isn't available or initialized.

A workaround was to rename the function with a "wh" prefix to ensure it lands after graphql.

Now `netlify dev`:

```bash
◈ Reloading function graphql...
◈ Reloaded function graphql
◈ Reloading function whInvalidatePostsHook...
◈ Reloaded function whInvalidatePostsHook
api | Starting API Server...
api | Loading server config from /redwoodjs/bighorn-website/api/server.config.js
api | Importing Server Functions... 
api | /graphql 245 ms
api | /whInvalidatePostsHook 283 ms
api | ...Done importing in 284 ms
api | 10:34:25 🌲 Server listening at http://localhost:8911
api | Took 320 ms
api | API server listening at http://localhost:8911/
api | GraphQL endpoint at http://localhost:8911/graphql
```

starts up without error.