### PR TITLE
fix: Attempt to more reliably load functions in order for Webhook Invalidation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,18 +124,34 @@ The GraphQL mutations:
 
 will purge the Posts from the response cache.
 
+```bash
+curl -X POST -H "Content-Type: application/json" --data '{ "query": "mutation { invalidatePosts }" }' https://redwoodjs.com/.netlify/functions/graphql
+```
+
+```bash
+curl -X POST -H "Content-Type: application/json" --data '{ "query": "mutation { invalidatePost(slug: \"rsc-now-in-redwoodjs\") }" }' https://redwoodjs.com/.netlify/functions/graphql
+```
+
+
+```bash
+curl -X POST -H "Content-Type: application/json" --data '{ "query": "query { post(slug: \"rsc-now-in-redwoodjs\") { id, title } }" }' https://redwoodjs.com/.netlify/functions/graphql
+```
+
+
 A webhook at /
 
 For example:
 
 ```bash
-curl http://localhost:8911/invalidatePostsHook
+curl http://localhost:8911/whInvalidatePostsHook
 ```
 
 Where the hostname is local or
 
 ```bash
-curl https://redwoodjs.com/.netlify/functions/invalidatePostsHook
+curl https://redwoodjs.com/.netlify/functions/whInvalidatePostsHook
 ```
 
 in production.
+
+Note: Since the webhook is signed, you'd need the secret as well, but Hashnode provides this for the webhook.

--- a/api/src/functions/whInvalidatePostsHook/whInvalidatePostsHook.ts
+++ b/api/src/functions/whInvalidatePostsHook/whInvalidatePostsHook.ts
@@ -6,6 +6,7 @@ import {
   WebhookVerificationError,
 } from '@redwoodjs/api/webhooks'
 
+import { handler as graphQLHandler } from 'src/functions/graphql'
 import { logger } from 'src/lib/logger'
 import { invalidatePosts } from 'src/services/hashnode'
 /**
@@ -20,6 +21,7 @@ import { invalidatePosts } from 'src/services/hashnode'
  */
 export const handler = async (event: APIGatewayEvent, _context: Context) => {
   logger.info(`${event.httpMethod} ${event.path}: invalidatePostsHook function`)
+  logger.info(graphQLHandler, 'Loaded GraphQL handler')
 
   try {
     const options = {


### PR DESCRIPTION
The prior PR did not 100% fix the issue -- sometimes the invalidatePosts was not yet initialized when deployed to Netlify.

I saw this "randomly" using `yarn netlify dev --live`.

This PR attempts to kick the graphql handler into being so the schema merges and the service is available.
