### PR TITLE
fix: Use cache directly, not service to invalidate posts

### DIFF
--- a/api/src/functions/whInvalidatePostsHook/whInvalidatePostsHook.ts
+++ b/api/src/functions/whInvalidatePostsHook/whInvalidatePostsHook.ts
@@ -6,9 +6,8 @@ import {
   WebhookVerificationError,
 } from '@redwoodjs/api/webhooks'
 
-import { handler as graphQLHandler } from 'src/functions/graphql'
+import { cache } from 'src/functions/graphql'
 import { logger } from 'src/lib/logger'
-import { invalidatePosts } from 'src/services/hashnode'
 /**
  * This function is the webhook handler for the Hashnode API.
  * It invalidates the cache for all posts.
@@ -21,7 +20,6 @@ import { invalidatePosts } from 'src/services/hashnode'
  */
 export const handler = async (event: APIGatewayEvent, _context: Context) => {
   logger.info(`${event.httpMethod} ${event.path}: invalidatePostsHook function`)
-  logger.info(graphQLHandler, 'Loaded GraphQL handler')
 
   try {
     const options = {
@@ -44,7 +42,8 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 
     logger.info({ webhook: 'whInvalidatePostsHook', options }, 'Verified!')
 
-    const status = await invalidatePosts()
+    const status = cache.invalidate([{ typename: 'Post' }])
+
     logger.info(
       { webhook: 'whInvalidatePostsHook', status },
       'Posts invalidated'


### PR DESCRIPTION
While the prior PR resolved the issue where the service was not available, it appears that when the function invokes in uses a separate instance of the in memory cache -- and thus did not bust it.

Busting via the graphql operation did bust:

```bash
curl -X POST -H "Content-Type: application/json" --data '{ "query": "mutation { invalidatePosts }" }' https://redwoodjs.com/.netlify/functions/graphql
```

Therefore, tis. his PR has the function not use the service to invalidate, but rather just interact with the cache directly -- and should be the same cache instance.

All this can go away if we use a Redis cache instead since we'll know we'd be talking to one shared, global cache instance