### PR TITLE
Replaces "embed-card" types from Hashnode with an actual embedded YouTube player

### DIFF
--- a/web/src/components/IndividualBlogPostCell/IndividualBlogPostCell.tsx
+++ b/web/src/components/IndividualBlogPostCell/IndividualBlogPostCell.tsx
@@ -10,6 +10,7 @@ import {
 } from '@redwoodjs/web'
 
 import { prettifyDate } from 'src/helpers/DateHelpers'
+import { replaceYouTubeLinks } from 'src/lib/helpers'
 
 import Avatar from '../Avatar/Avatar'
 
@@ -94,7 +95,9 @@ export const Success = ({
         {post?.content?.html && (
           <div
             className="blog-post"
-            dangerouslySetInnerHTML={{ __html: post.content.html }}
+            dangerouslySetInnerHTML={{
+              __html: replaceYouTubeLinks(post.content.html),
+            }}
           />
         )}
       </div>

--- a/web/src/lib/helpers.tsx
+++ b/web/src/lib/helpers.tsx
@@ -3,15 +3,15 @@
 // This replace is pretty basic in that it assumes the link is in the short URL
 // form like https://youtu.be/abc123 and always inside of an
 // <a class="embed-card"> tag from Hashnode.
-export const replaceYouTubeLinks = (text) => {
+export const replaceYouTubeLinks = (html: string) => {
   try {
     const youTubeRegex =
       /<a class="embed-card" href="https:\/\/youtu\.be\/(.*?)".*?<\/a>/g
     const youTubeIframe = `<iframe class="w-full aspect-video" src="https://www.youtube.com/embed/$1?rel=0&modestbranding=1" title="YouTube video player" frameborder="0" allowfullscreen></iframe>`
 
-    return text.replace(youTubeRegex, youTubeIframe)
+    return html.replace(youTubeRegex, youTubeIframe)
   } catch (e) {
     console.error(e)
-    return text
+    return html
   }
 }

--- a/web/src/lib/helpers.tsx
+++ b/web/src/lib/helpers.tsx
@@ -1,0 +1,17 @@
+// Replaces YouTube <a> links with <iframe> embeds
+
+// This replace is pretty basic in that it assumes the link is in the short URL
+// form like https://youtu.be/abc123 and always inside of an
+// <a class="embed-card"> tag from Hashnode.
+export const replaceYouTubeLinks = (text) => {
+  try {
+    const youTubeRegex =
+      /<a class="embed-card" href="https:\/\/youtu\.be\/(.*?)".*?<\/a>/g
+    const youTubeIframe = `<iframe class="w-full aspect-video" src="https://www.youtube.com/embed/$1?rel=0&modestbranding=1" title="YouTube video player" frameborder="0" allowfullscreen></iframe>`
+
+    return text.replace(youTubeRegex, youTubeIframe)
+  } catch (e) {
+    console.error(e)
+    return text
+  }
+}


### PR DESCRIPTION
Right now YouTube links are just showing as links in the blog, this replaces them with an `<iframe>` embed.

## Before
<img width="701" alt="image" src="https://github.com/redwoodjs/bighorn-website/assets/300/7608c704-fdcd-461f-8f36-7bfce4292b6c">

## After
<img width="710" alt="image" src="https://github.com/redwoodjs/bighorn-website/assets/300/fc731e4f-2c0a-4138-a070-40e0cf0e8265">

