### PR TITLE
feat: Setup experimental SSR feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "scripts": {
     "build:icons": "tsx ./scripts/build-icons.mts",
     "build:content": "contentlayer build"
+  },
+  "resolutions": {
+    "@apollo/client-react-streaming/superjson": "^1.12.2"
   }
 }

--- a/redwood.toml
+++ b/redwood.toml
@@ -19,3 +19,6 @@
   open = true
 [notifications]
   versionUpdates = ["latest"]
+
+[experimental.streamingSsr]
+  enabled = true

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     ]
   },
   "dependencies": {
+    "@apollo/client-react-streaming": "0.10.0",
     "@redwoodjs/forms": "8.0.0-canary.529",
     "@redwoodjs/router": "8.0.0-canary.529",
     "@redwoodjs/web": "8.0.0-canary.529",

--- a/web/src/Document.tsx
+++ b/web/src/Document.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+import { Css, Meta } from '@redwoodjs/web'
+import type { TagDescriptor } from '@redwoodjs/web'
+
+interface DocumentProps {
+  children: React.ReactNode
+  css: string[] // array of css import strings
+  meta?: TagDescriptor[]
+}
+
+export const Document: React.FC<DocumentProps> = ({ children, css, meta }) => {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="icon" type="image/png" href="/favicon.png" />
+        <Css css={css} />
+        <Meta tags={meta} />
+      </head>
+      <body>
+        <div id="redwood-app">{children}</div>
+      </body>
+    </html>
+  )
+}

--- a/web/src/entry.client.tsx
+++ b/web/src/entry.client.tsx
@@ -1,23 +1,33 @@
 import { hydrateRoot, createRoot } from 'react-dom/client'
 
 import App from './App'
+import { Document } from './Document'
+import Routes from './Routes'
+
 /**
  * When `#redwood-app` isn't empty then it's very likely that you're using
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
- * https://reactjs.org/docs/react-dom-client.html#hydrateroot
+ * https://react.dev/reference/react-dom/client/hydrateRoot
  */
 const redwoodAppElement = document.getElementById('redwood-app')
 
-if (!redwoodAppElement) {
-  throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it exists in your 'web/src/index.html' file."
-  )
-}
-
 if (redwoodAppElement.children?.length > 0) {
-  hydrateRoot(redwoodAppElement, <App />)
+  hydrateRoot(
+    document,
+    <Document css={window.__assetMap?.()?.css}>
+      <App>
+        <Routes />
+      </App>
+    </Document>
+  )
 } else {
-  const root = createRoot(redwoodAppElement)
-  root.render(<App />)
+  const root = createRoot(document)
+  root.render(
+    <Document css={window.__assetMap?.()?.css}>
+      <App>
+        <Routes />
+      </App>
+    </Document>
+  )
 }

--- a/web/src/entry.server.tsx
+++ b/web/src/entry.server.tsx
@@ -1,0 +1,20 @@
+import type { TagDescriptor } from '@redwoodjs/web'
+
+import App from './App'
+import { Document } from './Document'
+import Routes from './Routes'
+
+interface Props {
+  css: string[]
+  meta?: TagDescriptor[]
+}
+
+export const ServerEntry: React.FC<Props> = ({ css, meta }) => {
+  return (
+    <Document css={css} meta={meta}>
+      <App>
+        <Routes />
+      </App>
+    </Document>
+  )
+}

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -12,13 +12,16 @@ import WhatsIncluded from 'src/components/Home/WhatsIncluded/WhatsIncluded'
 import Newsletter from 'src/components/Newsletter/Newsletter'
 
 const HomePage = () => {
+  // TODO(jgmw): This is not an actual proposal for a solution but just highlighting the issue.
+  const origin =
+    typeof location !== 'undefined' ? location.origin : 'https://redwoodjs.com'
   return (
     <>
       <Metadata
         title="RedwoodJS: The App Framework for Startups"
         description="Grow from side project to startup with RedwoodJS. Combines React, GraphQL, and Prisma for a full-stack app framework."
         og={{
-          image: `${location.origin}/images/og.png`,
+          image: `${origin}/images/og.png`,
           url: 'https://redwoodjs.com',
         }}
       />

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -15,8 +15,7 @@ const viteConfig: UserConfig = {
     rollupOptions: {
       output: {
         assetFileNames: 'static/[name]-[hash][extname]',
-        entryFileNames: 'static/[name]-[hash].js',
-        chunkFileNames: 'static/[name]-[hash].js',
+        chunkFileNames: 'static/[name]-[hash].mjs',
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,6 +36,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@apollo/client-react-streaming@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@apollo/client-react-streaming@npm:0.10.0"
+  dependencies:
+    superjson: "npm:^1.12.2 || ^2.0.0"
+    ts-invariant: "npm:^0.10.3"
+  peerDependencies:
+    "@apollo/client": ^3.9.6
+    react: ^18
+  checksum: 10c0/b960665331cf52c05e033c91635df41ee311cd910d84b9f41b59be2496760f72591610c3eb746a46f57416f29bea7e2ee47e84e81fc3f0099db5087284f00905
+  languageName: node
+  linkType: hard
+
 "@apollo/client@npm:3.9.9":
   version: 3.9.9
   resolution: "@apollo/client@npm:3.9.9"
@@ -11631,6 +11644,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"copy-anything@npm:^3.0.2":
+  version: 3.0.5
+  resolution: "copy-anything@npm:3.0.5"
+  dependencies:
+    is-what: "npm:^4.1.8"
+  checksum: 10c0/01eadd500c7e1db71d32d95a3bfaaedcb839ef891c741f6305ab0461398056133de08f2d1bf4c392b364e7bdb7ce498513896e137a7a183ac2516b065c28a4fe
+  languageName: node
+  linkType: hard
+
 "copy-webpack-plugin@npm:11.0.0":
   version: 11.0.0
   resolution: "copy-webpack-plugin@npm:11.0.0"
@@ -16387,6 +16409,13 @@ __metadata:
     call-bind: "npm:^1.0.7"
     get-intrinsic: "npm:^1.2.4"
   checksum: 10c0/8ad6141b6a400e7ce7c7442a13928c676d07b1f315ab77d9912920bf5f4170622f43126f111615788f26c3b1871158a6797c862233124507db0bcc33a9537d1a
+  languageName: node
+  linkType: hard
+
+"is-what@npm:^4.1.8":
+  version: 4.1.16
+  resolution: "is-what@npm:4.1.16"
+  checksum: 10c0/611f1947776826dcf85b57cfb7bd3b3ea6f4b94a9c2f551d4a53f653cf0cb9d1e6518846648256d46ee6c91d114b6d09d2ac8a07306f7430c5900f87466aae5b
   languageName: node
   linkType: hard
 
@@ -23210,6 +23239,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"superjson@npm:^1.12.2":
+  version: 1.13.3
+  resolution: "superjson@npm:1.13.3"
+  dependencies:
+    copy-anything: "npm:^3.0.2"
+  checksum: 10c0/389a0a0c86884dd0558361af5d6d7f37102b71dda9595a665fe8b39d1ba0e57c859e39a9bd79b6f1fde6f4dcceac49a1c205f248d292744b2a340ee52846efdb
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^5.3.0, supports-color@npm:^5.5.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
@@ -24817,6 +24855,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "web@workspace:web"
   dependencies:
+    "@apollo/client-react-streaming": "npm:0.10.0"
     "@redwoodjs/forms": "npm:8.0.0-canary.529"
     "@redwoodjs/router": "npm:8.0.0-canary.529"
     "@redwoodjs/vite": "npm:8.0.0-canary.529"


### PR DESCRIPTION
**Work in progress**

Issues:
1. I had to change the non-standard settings in the vite config. I want to understand more about why they are there but it looks like ultimately redwood takes an opinion the location of your built files and so you have to remove the output for the entries.
2. Use of `location` is breaking SSR. I want to discuss this and see if we can find a way around it. My code in the homepage was just to confirm that indeed was the issue.

Notes:
Interesting that when you go and make a request with a bot user agent you get the meta tags but they are rendered outside of the HTML block. I hadn't known this:
<img width="737" alt="image" src="https://github.com/redwoodjs/bighorn-website/assets/56300765/0a1eb66f-cb62-42dc-8b9d-0af8fa1d9dd2">
