### PR TITLE
Add workflow to auto deploy app to fly

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,0 +1,19 @@
+# This workflow will deploy a Fly app on push to main
+# A guide on this can be found at: https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/
+
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy application
+    runs-on: ubuntu-latest
+    concurrency: deploy-group # Ensure only one deploy job runs at a time
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
This change adds continuous deployment to fly via a github action. This was produced by following the fly docs: https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/