### PR TITLE
Fix some accessibility issues

### DIFF
--- a/web/src/components/BlogCard/BlogCard.tsx
+++ b/web/src/components/BlogCard/BlogCard.tsx
@@ -27,9 +27,9 @@ interface BlogCardProps {
 const BlogCard = ({ post }: BlogCardProps) => {
   return (
     <article className="rounded-[4px] border-1 border-maiTai p-7 pb-5">
-      <h4 className="mb-2 text-sm font-bold uppercase text-maiTai">
+      <p className="mb-2 text-sm font-bold uppercase text-maiTai">
         {prettifyDate(post.publishedAt)}
-      </h4>
+      </p>
       <Link
         to={routes.blogIndividual({ slug: post.slug })}
         className="text-white hover:text-sulu"

--- a/web/src/components/Home/NavHome/NavHome.tsx
+++ b/web/src/components/Home/NavHome/NavHome.tsx
@@ -219,6 +219,7 @@ const Nav = () => {
               onClick={() => {
                 setIsThemeDropdownShowing((prevValue) => !prevValue)
               }}
+              aria-label="switch theme"
             >
               <Icon
                 id={selectedTheme}

--- a/web/src/components/Home/RedwoodIs/RedwoodIs.tsx
+++ b/web/src/components/Home/RedwoodIs/RedwoodIs.tsx
@@ -43,7 +43,7 @@ const RedwoodIs = () => {
           >
             {Constants.CREATE_REDWOOD_SCRIPT}
           </div>
-          <button onClick={copyToClipboard}>
+          <button onClick={copyToClipboard} aria-label="copy install command">
             {isCopied ? (
               <span className="text-sulu">
                 <Icon id="check" />

--- a/web/src/components/Nav/Nav.tsx
+++ b/web/src/components/Nav/Nav.tsx
@@ -226,6 +226,7 @@ const Nav = () => {
               onClick={() => {
                 setIsThemeDropdownShowing((prevValue) => !prevValue)
               }}
+              aria-label="switch theme"
             >
               <Icon
                 id={selectedTheme}


### PR DESCRIPTION
The lighthouse score for the sites accessibility was 78 when I tested locally. It had 3 errors:
1. A couple of buttons were missing aria labels
2. There was an instance where the h tags weren't sequential in order
3. The colouring wasn't high enough contrast

This PR adds labels to the two buttons and replaces a h4 with p tag to avoid the non-sequential ordering.

I didn't address the colour contrast complaint because thats a harder one.  