### PR TITLE
Add height param to profile picture image requests

### DIFF
--- a/web/src/components/BlogCard/BlogCard.tsx
+++ b/web/src/components/BlogCard/BlogCard.tsx
@@ -25,6 +25,8 @@ interface BlogCardProps {
 }
 
 const BlogCard = ({ post }: BlogCardProps) => {
+  const profilePictureUrl = new URL(post.author.profilePicture)
+  profilePictureUrl.searchParams.set('height', '128')
   return (
     <article className="rounded-[4px] border-1 border-maiTai p-7 pb-5">
       <h4 className="mb-2 text-sm font-bold uppercase text-maiTai">
@@ -54,7 +56,7 @@ const BlogCard = ({ post }: BlogCardProps) => {
             className="text-black dark:text-white"
           />
         </Link>
-        <Avatar alt={post.author.name} src={post.author.profilePicture} />
+        <Avatar alt={post.author.name} src={profilePictureUrl} />
       </div>
     </article>
   )

--- a/web/src/components/BlogListItem/BlogListItem.tsx
+++ b/web/src/components/BlogListItem/BlogListItem.tsx
@@ -23,6 +23,8 @@ interface Props {
 }
 
 const BlogListItem = ({ post }: Props) => {
+  const profilePictureUrl = new URL(post.author.profilePicture)
+  profilePictureUrl.searchParams.set('height', '128')
   return (
     <article>
       <h3 className="mb-2 text-sm font-bold uppercase text-maiTai">
@@ -55,7 +57,7 @@ const BlogListItem = ({ post }: Props) => {
 
       {/* author */}
       <div className="flex items-center gap-x-6">
-        <Avatar alt={post.author.name} src={post.author.profilePicture} />
+        <Avatar alt={post.author.name} src={profilePictureUrl} />
         <div>
           <div className="text-lg">{post.author.name}</div>
         </div>

--- a/web/src/components/IndividualBlogPostCell/IndividualBlogPostCell.tsx
+++ b/web/src/components/IndividualBlogPostCell/IndividualBlogPostCell.tsx
@@ -84,6 +84,10 @@ export const Success = ({
   }, [post])
 
   const { origin } = useLocation()
+
+  const profilePictureUrl = new URL(post.author.profilePicture)
+  profilePictureUrl.searchParams.set('height', '128')
+
   return (
     <div className="page-grid">
       <Metadata
@@ -104,7 +108,7 @@ export const Success = ({
         </h2>
 
         <div className="mb-10 flex items-center gap-3">
-          <Avatar alt={post.author.name} src={post.author.profilePicture} />
+          <Avatar alt={post.author.name} src={profilePictureUrl} />
           <div className="text-lg text-black dark:text-white">
             {post.author.name}
           </div>


### PR DESCRIPTION
Currently when we load a profile picture we ask hashnode for the full image.

Rob's face is returned at over 400px and around 425kB. The profile pictures are displayed at about 40px in size (I wiggled the page around and they appear to always be shown at this size and not scale in anyway). I've added a height of 128px to the request. This reduces the size down to about 8.8kb (2%) in this example case. It's still 2.5x the size drawn on the page but that ensures it's still crisp when looking at it. 

I have repeated the code a few times here so if we prefer we could pull it out into some helper function but it felt okay for just now. 