### PR TITLE
Fix: missing dark prefixes on some elements

### DIFF
--- a/web/src/components/EventItem/EventItem.tsx
+++ b/web/src/components/EventItem/EventItem.tsx
@@ -32,7 +32,9 @@ const EventItem = ({ date, title, description, rsvp = '' }: EventItemProps) => {
           {getDay(date)} at {getTime(date)} PST
         </div>
       </div>
-      <h4 className="mb-2 text-lg font-bold leading-6 text-white">{title}</h4>
+      <h4 className="mb-2 text-lg font-bold leading-6 dark:text-white">
+        {title}
+      </h4>
       <p className="mb-4 text-lg leading-6 text-battleshipGray">
         {description}
       </p>

--- a/web/src/components/Newsletter/Newsletter.tsx
+++ b/web/src/components/Newsletter/Newsletter.tsx
@@ -43,7 +43,7 @@ const Newsletter = () => {
             <EmailField
               name="email"
               placeholder="your@email.com"
-              className="h-[53px] w-full rounded-[4px] border-1 border-battleshipGray bg-transparent px-7 font-sans text-lg text-white transition-all sm:flex-1"
+              className="h-[53px] w-full rounded-[4px] border-1 border-battleshipGray bg-transparent px-7 font-sans text-lg transition-all sm:flex-1 dark:text-white"
             />
             <button
               type="submit"


### PR DESCRIPTION
Hi team! This simple change addresses two instance of missing `dark:` prefixes.

<img width="735" alt="image" src="https://github.com/user-attachments/assets/fdfd01d8-9ded-40a6-930b-76d6995e5e6a">

<img width="747" alt="image" src="https://github.com/user-attachments/assets/616ad4f4-6396-4006-8559-d677a6c6e419">
