### PR TITLE
update `prettifyDate` to take date input

### DIFF
--- a/web/src/components/BlogCard/BlogCard.tsx
+++ b/web/src/components/BlogCard/BlogCard.tsx
@@ -20,7 +20,7 @@ const BlogCard = ({ post }: BlogCardProps) => {
   return (
     <article className="rounded-[4px] border-1 border-maiTai p-7 pb-5">
       <p className="mb-2 text-sm font-bold uppercase text-maiTai">
-        {prettifyDate(post.publishedAt.toString())}
+        {prettifyDate(post.publishedAt)}
       </p>
       <Link
         to={routes.blogIndividual({ slug: post.slug })}

--- a/web/src/components/BlogListItem/BlogListItem.tsx
+++ b/web/src/components/BlogListItem/BlogListItem.tsx
@@ -16,7 +16,7 @@ const BlogListItem = ({ post }: Props) => {
   return (
     <article>
       <h3 className="mb-2 text-sm font-bold uppercase text-maiTai">
-        {prettifyDate(post.publishedAt.toString())}
+        {prettifyDate(post.publishedAt)}
       </h3>
       <div className="mb-3 flex flex-col md:flex-row md:items-center md:justify-between">
         <h2 className="mb-2 font-sans text-2xl font-bold md:mb-0">

--- a/web/src/components/ChangelogDetails/ChangelogDetails.tsx
+++ b/web/src/components/ChangelogDetails/ChangelogDetails.tsx
@@ -1,6 +1,11 @@
 import { prettifyDate } from 'src/helpers/DateHelpers'
 
-const ChangelogDetails = ({ children, date }) => {
+type ChangelogDetailsProps = {
+  children: React.ReactNode
+  date: Date
+}
+
+const ChangelogDetails = ({ children, date }: ChangelogDetailsProps) => {
   return (
     <div className="changelog mb-10">
       <strong className="mb-8 block text-2xl leading-relaxed">

--- a/web/src/helpers/DateHelpers.ts
+++ b/web/src/helpers/DateHelpers.ts
@@ -1,10 +1,10 @@
 /**
- * prettifyDate
- * @param date {string} - A date string, in this format: 2024-02-08T07:59:20.092Z
+ * Converts a date to a consistent pretty string format
+ * @param date {Date} - A javascript date object
  * @returns {string} - A date string, in this format: February 8, 2024
  */
-export const prettifyDate = (date: string) => {
-  return new Date(date).toLocaleDateString('en-US', {
+export const prettifyDate = (date: Date) => {
+  return date.toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',

--- a/web/src/pages/BlogIndividualPage/BlogIndividualPage.tsx
+++ b/web/src/pages/BlogIndividualPage/BlogIndividualPage.tsx
@@ -38,7 +38,7 @@ const BlogIndividualPage = ({ slug }) => {
         />
         <div className="col-span-12">
           <h4 className="mb-2 text-sm font-bold uppercase text-maiTai">
-            {prettifyDate(post.publishedAt.toString())}
+            {prettifyDate(post.publishedAt)}
           </h4>
           <h1 className="section-heading mb-5">{post.title}</h1>
           <h2 className="mb-10 text-3xl font-thin text-black dark:text-white">


### PR DESCRIPTION
When we switched to having the content directly in the repo the dates of blogs become true JS dates and not strings. This change updates the `prettifyDate` function to take in these dates so we don't have to convert between date and string repeatedly. 