### PR TITLE
Add preload hints for css and hero image

### DIFF
--- a/web/src/Document.tsx
+++ b/web/src/Document.tsx
@@ -18,6 +18,14 @@ export const Document: React.FC<DocumentProps> = ({ children, css, meta }) => {
         <link rel="icon" type="image/png" href="/favicon.png" />
         <Css css={css} />
         <Meta tags={meta} />
+
+        {/* preload hints for css */}
+        <link rel="preload" href="https://use.typekit.net/sjm8rub.css" as="style" />
+        <link rel="preload" href="https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,200;0,400;0,700;1,400;1,700;1,900&display=swap" as="style" />
+        <link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap" as="style" />
+
+        {/* preload hints for images */}
+        <link rel="preload" fetchPriority="high" href="/images/hero.avif" as="image" />
       </head>
       <body>
         <div id="redwood-app">{children}</div>


### PR DESCRIPTION
Another potential performance improvement driven by lighthouse insights. By adding preload instructions to the hero image and css imports we should see the browser fetch those resources sooner and improve page performance.