### PR TITLE
Minify during build and add additional preload

### DIFF
--- a/web/src/Document.tsx
+++ b/web/src/Document.tsx
@@ -21,6 +21,7 @@ export const Document: React.FC<DocumentProps> = ({ children, css, meta }) => {
 
         {/* preload hints for css */}
         <link rel="preload" href="https://use.typekit.net/sjm8rub.css" as="style" />
+        <link rel="preload" href="https://p.typekit.net/p.css?s=1&k=sjm8rub&ht=tk&f=38944&a=8145&app=typekit&e=css" as="style" />
         <link rel="preload" href="https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,200;0,400;0,700;1,400;1,700;1,900&display=swap" as="style" />
         <link rel="preload" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap" as="style" />
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -51,6 +51,7 @@ export default defineConfig(async () => {
           chunkFileNames: 'static/[name]-[hash].mjs',
         },
       },
+      minify: true,
     },
     ssr: {
       noExternal: ['react-tweet'],


### PR DESCRIPTION
Redwood disabled minification during building for the experimental ssr/rsc features. I have re-enabled it here so that we are minifying assets during build.

Also a follow up to https://github.com/redwoodjs/bighorn-website/pull/53 by adding an additional css preload - this time for some third party css import call. 