### PR TITLE
fix: make iframes 'aspect-video'

### DIFF
--- a/web/src/content/posts/middleware-in-redwoodjs.mdx
+++ b/web/src/content/posts/middleware-in-redwoodjs.mdx
@@ -61,7 +61,7 @@ yarn rw experimental setup-streaming-ssr -f
 
 I go through how this works in this screencast, and break down some of the concepts and how a request will flow through middleware. We'll also do a breakdown of the dbAuth middleware, to see how we can use these concepts in practice.
 
-<iframe className="w-full aspect-video border-0" src="https://www.youtube.com/embed/PFmJxzBtlfk?rel=0&modestbranding=1" title="YouTube video player" allowFullScreen></iframe>
+<iframe src="https://www.youtube.com/embed/PFmJxzBtlfk?rel=0&modestbranding=1" title="YouTube video player" allowFullScreen></iframe>
 
 ## Summary of concepts in the video
 
@@ -255,4 +255,4 @@ This is something we are considering changing, so if you have suggestions on wha
 
 I also have a practical example of how these middleware concepts are applied. Check out the breakdown of the dbAuth middleware and how authentication works with server rendering in this video:
 
-<iframe className="w-full aspect-video border-0" src="https://www.youtube.com/embed/DrBe_uc31No?rel=0&modestbranding=1" title="YouTube video player" allowFullScreen></iframe>
+<iframe src="https://www.youtube.com/embed/DrBe_uc31No?rel=0&modestbranding=1" title="YouTube video player" allowFullScreen></iframe>

--- a/web/src/content/posts/rsc-now-in-redwoodjs.mdx
+++ b/web/src/content/posts/rsc-now-in-redwoodjs.mdx
@@ -9,7 +9,7 @@ Core team lead Tobbe [announced](https://community.redwoodjs.com/t/react-server-
 
 You can also watch a video covering how RSC works in Redwood and how to convert an existing GraphQL app:
 
-<iframe className="w-full aspect-video border-0" src="https://www.youtube.com/embed/5IZv3khsx0o?rel=0&modestbranding=1" title="YouTube video player" allowFullScreen></iframe>
+<iframe src="https://www.youtube.com/embed/5IZv3khsx0o?rel=0&modestbranding=1" title="YouTube video player" allowFullScreen />
 
 ## Why RSC?
 
@@ -613,7 +613,7 @@ So as long as the client component (`<Theme>` in this case) isn't importing thos
 
 You can also watch a video covering creating your own app from scratch:
 
-<iframe className="w-full aspect-video border-0" src="https://www.youtube.com/embed/PW0ulmCpWn4?rel=0&modestbranding=1" title="YouTube video player" allowFullScreen></iframe>
+<iframe src="https://www.youtube.com/embed/PW0ulmCpWn4?rel=0&modestbranding=1" title="YouTube video player" allowFullScreen></iframe>
 
 ### Getting Started
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -129,6 +129,10 @@
     @apply border-1 border-neutral-200 dark:border-neutral-800 p-2;
   }
 
+  iframe {
+    @apply w-full aspect-video border-0 mb-10;
+  }
+
   /* -------------------------- HEADER ------------------------------------- */
   /* logo - right click menu */
   .right-click-menu {


### PR DESCRIPTION
Related to: https://github.com/redwoodjs/bighorn-website/pull/57

That PR does a more complex and indeed more robust check to set the youtube video the correct aspect ratio. This PR for the moment just sets them all to 16/9 aka aspect-video in tailwind. 